### PR TITLE
Create MockWallet and rough out useTransaction test

### DIFF
--- a/packages/react/src/hooks/transactions/useTransaction.test.ts
+++ b/packages/react/src/hooks/transactions/useTransaction.test.ts
@@ -1,0 +1,84 @@
+import { wallets } from 'wagmi-testing'
+
+import { useConnect } from '..'
+
+import { actHook, renderHook } from '../../../test'
+import { Config, useTransaction } from './useTransaction'
+
+const transaction = {
+  request: {
+    from: wallets.ethers1.address,
+    to: wallets.ethers2.address,
+  },
+}
+
+const useTransactionWithConnect = (config: { transaction?: Config } = {}) => {
+  const connect = useConnect()
+  const transaction = useTransaction(config.transaction)
+  return { connect, transaction } as const
+}
+
+describe('useTransaction', () => {
+  it('on mount', async () => {
+    const { result } = renderHook(() => useTransaction())
+    expect(result.current[0]).toMatchInlineSnapshot(`
+      {
+        "data": undefined,
+        "error": undefined,
+        "loading": false,
+      }
+    `)
+    expect(result.current[1]).toBeDefined()
+  })
+
+  describe('transaction', () => {
+    it('uses config', async () => {
+      const { result } = renderHook(() =>
+        useTransactionWithConnect({
+          transaction,
+        }),
+      )
+
+      expect(result.current.transaction[0]).toMatchInlineSnapshot(`
+        {
+          "data": undefined,
+          "error": undefined,
+          "loading": false,
+        }
+      `)
+
+      await actHook(async () => {
+        const mockConnector = result.current.connect[0].data.connectors[0]
+        await result.current.connect[1](mockConnector)
+        await result.current.transaction[1]()
+      })
+
+      expect(result.current.transaction[0]).toMatchInlineSnapshot(`
+        {
+          "data": {
+            from: "0x012363d61bdc53d0290a0f25e9c89f8257550fb8",
+          },
+          "error": undefined,
+          "loading": false,
+        }
+      `)
+    })
+
+    it('has error', async () => {
+      const { result } = renderHook(() => useTransactionWithConnect())
+
+      await actHook(async () => {
+        const mockConnector = result.current.connect[0].data.connectors[0]
+        await result.current.connect[1](mockConnector)
+
+        const res = await result.current.transaction[1]()
+        expect(res).toMatchInlineSnapshot(`
+          {
+            "data": undefined,
+            "error": [Error: request is required],
+          }
+        `)
+      })
+    })
+  })
+})

--- a/packages/testing/src/connectors/mockProvider.test.ts
+++ b/packages/testing/src/connectors/mockProvider.test.ts
@@ -1,17 +1,18 @@
-import { ethers } from 'ethers'
-
 import { contracts, wallets } from '../constants'
 import { MockProvider } from './mockProvider'
+import { MockWallet } from './mockWallet'
 
 describe('MockProvider', () => {
   let provider: MockProvider
-  let wallet: ethers.Wallet
+  let wallet: MockWallet
   beforeEach(() => {
     provider = new MockProvider({
       network: 1,
       privateKey: wallets.ethers1.privateKey,
     })
-    wallet = new ethers.Wallet(wallets.ethers1.privateKey)
+    wallet = new MockWallet({
+      privateKey: wallets.ethers1.privateKey,
+    })
   })
 
   it('inits', () => {

--- a/packages/testing/src/connectors/mockProvider.ts
+++ b/packages/testing/src/connectors/mockProvider.ts
@@ -35,7 +35,10 @@ export class MockProvider extends ethers.providers.BaseProvider {
   async enable() {
     if (this.#options.flags?.failConnect) throw new UserRejectedRequestError()
     if (!this.#wallet)
-      this.#wallet = new MockWallet({ privateKey: this.#options.privateKey })
+      this.#wallet = new MockWallet({
+        privateKey: this.#options.privateKey,
+        provider: this,
+      })
     const address = await this.#wallet.getAddress()
     this.events.emit('accountsChanged', [address])
     return [address]

--- a/packages/testing/src/connectors/mockProvider.ts
+++ b/packages/testing/src/connectors/mockProvider.ts
@@ -3,6 +3,8 @@ import { ethers } from 'ethers'
 import { UserRejectedRequestError } from 'wagmi-private'
 import { getAddress } from 'ethers/lib/utils'
 
+import { MockWallet } from './mockWallet'
+
 export type MockProviderOptions = {
   flags?: {
     failConnect?: boolean
@@ -23,7 +25,7 @@ export class MockProvider extends ethers.providers.BaseProvider {
   events = new EventEmitter<Events>()
 
   #options: MockProviderOptions
-  #wallet?: ethers.Wallet
+  #wallet?: MockWallet
 
   constructor(options: MockProviderOptions) {
     super(options.network)
@@ -33,7 +35,7 @@ export class MockProvider extends ethers.providers.BaseProvider {
   async enable() {
     if (this.#options.flags?.failConnect) throw new UserRejectedRequestError()
     if (!this.#wallet)
-      this.#wallet = new ethers.Wallet(this.#options.privateKey)
+      this.#wallet = new MockWallet({ privateKey: this.#options.privateKey })
     const address = await this.#wallet.getAddress()
     this.events.emit('accountsChanged', [address])
     return [address]

--- a/packages/testing/src/connectors/mockWallet.ts
+++ b/packages/testing/src/connectors/mockWallet.ts
@@ -1,0 +1,11 @@
+import { ethers } from 'ethers'
+
+interface MockWalletOptions {
+  privateKey: string
+}
+
+export class MockWallet extends ethers.Wallet {
+  constructor(options: MockWalletOptions) {
+    super(options.privateKey)
+  }
+}

--- a/packages/testing/src/connectors/mockWallet.ts
+++ b/packages/testing/src/connectors/mockWallet.ts
@@ -1,11 +1,21 @@
 import { ethers } from 'ethers'
 
+import { MockProvider } from './mockProvider'
+
 interface MockWalletOptions {
   privateKey: string
+  provider: MockProvider
 }
 
 export class MockWallet extends ethers.Wallet {
   constructor(options: MockWalletOptions) {
-    super(options.privateKey)
+    super(options.privateKey, options.provider)
+  }
+
+  async sendTransaction(transaction) {
+    // TODO
+    return {
+      from: transaction.from,
+    }
   }
 }


### PR DESCRIPTION
This MR introduces the MockWallet class so we can test the `useTransaction` and `useWaitForTransaction` hooks.